### PR TITLE
Fix Windows executable path

### DIFF
--- a/PegRules.make
+++ b/PegRules.make
@@ -1,11 +1,11 @@
 .SUFFIXES: .peg .go
 
 CP = cp
-PEGPARSER =  @echo $$GOPATH/bin/pegparser
+PEGPARSER = @echo $$GOPATH/bin/pegparser
 buildPeg = $(PEGPARSER) "-peg=$(1)" -notest -ignore="$(2)" -testfile="$(3)" -outpath "$(dir $@)" -generator="$(4)"
 
 $(PEGPARSER):
-	go build github.com/quarnster/parser/pegparser
+	go install github.com/quarnster/parser/pegparser
 
 %.go: %.peg $(PEGPARSER)
 	$(call buildPeg,$<,$(ignore_$(subst .go,,$(notdir $@))),$(testfile_$(subst .go,,$(notdir $@))),go)

--- a/PegRules.make
+++ b/PegRules.make
@@ -1,11 +1,11 @@
 .SUFFIXES: .peg .go
 
 CP = cp
-PEGPARSER = $(firstword $(subst :, ,$(GOPATH)))/bin/pegparser
+PEGPARSER =  @echo $$GOPATH/bin/pegparser
 buildPeg = $(PEGPARSER) "-peg=$(1)" -notest -ignore="$(2)" -testfile="$(3)" -outpath "$(dir $@)" -generator="$(4)"
 
 $(PEGPARSER):
-	go build -o $(PEGPARSER) github.com/quarnster/parser/pegparser
+	go build github.com/quarnster/parser/pegparser
 
 %.go: %.peg $(PEGPARSER)
 	$(call buildPeg,$<,$(ignore_$(subst .go,,$(notdir $@))),$(testfile_$(subst .go,,$(notdir $@))),go)


### PR DESCRIPTION
On Windows, the executable path was "C\bin\pegparser", which did not
play well with the command line. And then there is the issue that
issuing the "-o" flag to go build omits the ".exe" extension.
